### PR TITLE
v1.1.2 fix kiosk.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This plugin has only been tested in Cordova 3.2 or greater, and its use in previ
 
 - [Installation](#installation)
 - [Methods](#methods)
-    - [Kiosk.setKiosEnabled](#kioskSetKioskEnabled)
+    - [Kiosk.setKioskEnabled](#kioskSetKioskEnabled)
     - [Kiosk.switchLauncher](#kioskSwitchLauncher)
     - [Kiosk.isInKiosk](#kioskIsInKiosk)
     - [Kiosk.isSetAsLauncher](#kioskIsSetAsLauncher)
@@ -38,11 +38,11 @@ From github latest (may not be stable)
 
 # Methods
 
-## Kiosk.setKiosEnabled
+## Kiosk.setKioskEnabled
 
 Enables/disables kiosk mode and
 
-    Kiosk.setKiosEnabled(boolean);
+    Kiosk.setKioskEnabled(boolean);
 
 
 ## Kiosk.switchLauncher
@@ -64,7 +64,17 @@ Checks to see if the app is set as a launcher
 
     Kiosk.isSetAsLauncher(function(isSetAsLauncher){ ... })
 
+## Kiosk.setKeysRunning
+
+Keycode whose event propagation should not be prevented - Brightness up/down is now allowed, other prevented
+
+    Kiosk.setKeysRunning([220, 221])  //KEYCODE_BRIGHTNESS_DOWN, KEYCODE_BRIGHTNESS_UP
+
+[Android Keycode review](https://developer.android.com/reference/android/view/KeyEvent#KEYCODE_0)
+
 # Releases
+- 1.2.0
+    - Added keys[] enabled to have action in kioskMode
 - 1.1.2
     - Remove bug on kiosk.js for android 4+ - 'Uncaught SyntaxError: Unexpected token ('
 - 1.0.3

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ Checks to see if the app is set as a launcher
     Kiosk.isSetAsLauncher(function(isSetAsLauncher){ ... })
 
 # Releases
+- 1.1.2
+    - Remove bug on kiosk.js for android 4+ - 'Uncaught SyntaxError: Unexpected token ('
 - 1.0.3
     - Removes fullscreen bug
 - 1.0.2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-kiosk-launcher",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Cordova plugin to make a Cordova application a launcher",
   "cordova": {
     "id": "cordova-plugin-kiosk-launcher",

--- a/src/android/Kiosk.java
+++ b/src/android/Kiosk.java
@@ -7,6 +7,8 @@ import org.apache.cordova.*;
 import android.widget.*;
 import org.json.JSONArray;
 import org.cordova.plugin.labs.kiosk.KioskActivity;
+import java.lang.Integer;
+import java.util.HashSet;
 
 public class Kiosk extends CordovaPlugin {
 
@@ -14,6 +16,7 @@ public class Kiosk extends CordovaPlugin {
     public static final String SWITCH_LAUNCHER = "switchLauncher";
     public static final String IS_IN_KIOSK = "isInKiosk";
     public static final String IS_SET_AS_LAUNCHER = "isSetAsLauncher";
+    public static final String SET_KEYS_RUNNING = "setKeysRunning";
 
     @Override
     public boolean execute(String action, JSONArray args, CallbackContext callbackContext) {
@@ -43,6 +46,17 @@ public class Kiosk extends CordovaPlugin {
                     cordova.getActivity().startActivity(chooser);
                 }
 
+                callbackContext.success();
+                return true;
+            } else if (SET_KEYS_RUNNING.equals(action)) {
+                
+                System.out.println("setKeysRunning: " + args.toString());
+                HashSet<Integer> runningKeys = new HashSet<Integer>();
+                for (int i = 0; i < args.length(); i++) {
+                    runningKeys.add(args.optInt(i));
+                }
+                KioskActivity.runningKeys = runningKeys;
+                
                 callbackContext.success();
                 return true;
             }

--- a/src/android/KioskActivity.java
+++ b/src/android/KioskActivity.java
@@ -4,13 +4,20 @@ import android.app.Activity;
 import android.app.ActivityManager;
 import android.content.Context;
 import android.os.Bundle;
+import android.view.KeyEvent;
 import org.apache.cordova.*;
 import android.widget.*;
+
+import java.lang.Integer;
+import java.util.Collections;
+import java.util.Set;
 
 public class KioskActivity extends CordovaActivity {
 
     public static volatile boolean running = false;
     public static volatile boolean kioskModeEnabled = false;
+
+    public static volatile Set<Integer> runningKeys = Collections.EMPTY_SET;
 
     protected void onStart() {
         super.onStart();
@@ -34,6 +41,12 @@ public class KioskActivity extends CordovaActivity {
         }
 
         loadUrl(launchUrl);
+    }
+
+    @Override
+    public boolean onKeyDown(int keyCode, KeyEvent event) {
+        System.out.println("onKeyDown event: keyCode = " + event.getKeyCode());
+        return !runningKeys.contains(event.getKeyCode()); // event not being propagated if not allowed
     }
 
     @Override

--- a/www/kiosk.js
+++ b/www/kiosk.js
@@ -1,7 +1,7 @@
 var exec = require("cordova/exec");
 
 var Kiosk = {
-  setKioskEnabled(enabled) {
+  setKioskEnabled: function(enabled) {
     exec(null, null, "Kiosk", "setKioskEnabled", [!!enabled]);
   },
 

--- a/www/kiosk.js
+++ b/www/kiosk.js
@@ -35,6 +35,17 @@ var Kiosk = {
       "isSetAsLauncher",
       []
     );
+  }, 
+
+  setKeysRunning: function (keyCodes) {
+    exec(
+      null, 
+      function (error) {
+        alert("Kiosk.setKeysRunning failed: " + error);
+      }, 
+      "Kiosk", 
+      "setKeysRunning", 
+      keyCodes);
   }
 };
 


### PR DESCRIPTION
Hi @guatedude2 

in Android 4.4 where i tested the kiosk mode, in console i have a bug related to 5th row of kiosk.js.

`Uncaught SyntaxError: Unexpected token (  - :8080/plugins/cordova-plugin-kiosk-launcher/www/kiosk.js:5`

The sintax of function setKioskEnabled causes the problem. In Android 7 no problem related. 

---

Added keycode allowed and prevent other all keycode in kiosk mode