### PR TITLE
Remove theme from plugin.xml for Androidx compatibility

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -24,7 +24,7 @@
         </config-file>
 
         <edit-config file="AndroidManifest.xml" target="/manifest/application/activity[@android:label='@string/activity_name']" mode="merge">
-            <activity android:name="org.cordova.plugin.labs.kiosk.KioskActivity" android:keepScreenOn="true" android:theme="@android:style/Theme.DeviceDefault.NoActionBar">
+            <activity android:name="org.cordova.plugin.labs.kiosk.KioskActivity" android:keepScreenOn="true">
             </activity>
         </edit-config>
 


### PR DESCRIPTION
Cordova 10 uses Androidx by default. 

Therefore, the referenced theme (`android:theme="@android:style/Theme.DeviceDefault.NoActionBar"`) doesn't exist anymore. In order to keep compatibility with non Androidx versions, I removed the reference in plugin.xml.

